### PR TITLE
fix(UsageGuidelines): wrap content in a span

### DIFF
--- a/src/components/usage-guidelines/usage-guidelines.jsx
+++ b/src/components/usage-guidelines/usage-guidelines.jsx
@@ -13,7 +13,7 @@ export const UsageGuidelines = ({ guidelines }) => {
         // eslint-disable-next-line react/no-array-index-key
         <span id={index} key={index} className={bemHelper({ element: 'guideline' })}>
           <span className={bemHelper({ element: 'icon' })}>➡️</span>
-          {guideline}
+          <span>{guideline}</span>
         </span>
       )),
     [guidelines],


### PR DESCRIPTION
The content provided to the component can be multiple DOM elements so they are all flexed in the same container, so wrapping them in a single div will keep only the icon and content flexed in that container. 

https://monday.monday.com/boards/3532714909/pulses/5234574183

![Screenshot 2023-09-28 at 15 24 08](https://github.com/mondaycom/vibe-storybook-components/assets/18269880/4b5ffb19-2607-4dde-b9d3-fae1d201c2e5)
