### PR TITLE
fix: types

### DIFF
--- a/src/components/storybook-link/storybook-link.tsx
+++ b/src/components/storybook-link/storybook-link.tsx
@@ -1,13 +1,14 @@
 import { FC, useEffect, useState } from 'react';
-import Link, { LinkProps } from '../link/link';
+import Link from '../link/link';
 import { hrefTo } from '@storybook/addon-links';
 import { LinkSize } from '../link/LinkConstants';
 import { withStaticProps } from '../../types';
 
-interface StorybookLinkProps extends LinkProps {
+interface StorybookLinkProps {
   page: string;
   children: string;
   story?: string;
+  size?: LinkSize;
 }
 
 const StorybookLink: FC<StorybookLinkProps> & { sizes?: typeof LinkSize } = ({ page, story = '', children, size }) => {


### PR DESCRIPTION
When extending `LinkProps` it's expecting `href` as it's mandatory, so I removed the extends and just added the only prop missing besides `href`
https://monday.monday.com/boards/3532714909/pulses/5540093456